### PR TITLE
Fix settings window not appearing and surface scrolling capture

### DIFF
--- a/DodoShot/DodoShotApp.swift
+++ b/DodoShot/DodoShotApp.swift
@@ -265,11 +265,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             window.center()
             window.isReleasedWhenClosed = false
             window.contentView = NSHostingView(rootView: SettingsView())
+            // Ensure the window joins the active Space and floats above other
+            // apps. As an accessory (LSUIElement) app we can't reliably pull a
+            // plain window to the front, so it would otherwise open hidden
+            // behind everything — appearing as "nothing happens" on click.
+            window.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+            window.center()
             settingsWindow = window
         }
 
-        settingsWindow?.makeKeyAndOrderFront(nil)
+        // An accessory app cannot reliably foreground a window with
+        // makeKeyAndOrderFront alone. Briefly become a regular app so we own
+        // the foreground, bring the window forward, then restore the policy.
+        let restorePolicy = NSApp.activationPolicy()
+        if restorePolicy != .regular {
+            NSApp.setActivationPolicy(.regular)
+        }
+
         NSApp.activate(ignoringOtherApps: true)
+        settingsWindow?.makeKeyAndOrderFront(nil)
+        settingsWindow?.orderFrontRegardless()
+
+        // Restore the original activation policy once the window is up so the
+        // app stays a menu-bar item (no Dock icon) when not configured to show one.
+        if restorePolicy != .regular {
+            DispatchQueue.main.async { [weak self] in
+                guard self?.settingsWindow != nil else { return }
+                NSApp.setActivationPolicy(restorePolicy)
+            }
+        }
     }
 
     @objc private func quitApp() {

--- a/DodoShot/Views/MenuBarView.swift
+++ b/DodoShot/Views/MenuBarView.swift
@@ -160,6 +160,14 @@ struct MenuBarView: View {
             ) {
                 startOCRCapture()
             }
+
+            MenuToolButton(
+                icon: "arrow.down.doc",
+                label: L10n.Menu.scrolling,
+                color: .indigo
+            ) {
+                startScrollingCapture()
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -265,6 +273,13 @@ struct MenuBarView: View {
         NSApp.sendAction(#selector(AppDelegate.closePopover), to: nil, from: nil)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             ScreenCaptureService.shared.startOCRCapture()
+        }
+    }
+
+    private func startScrollingCapture() {
+        NSApp.sendAction(#selector(AppDelegate.closePopover), to: nil, from: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            ScreenCaptureService.shared.startScrollingCapture()
         }
     }
 


### PR DESCRIPTION
Closes #21

## Summary

Fixes two issues reported by a user on macOS who could not open settings (clicking the gear "showed nothing") and could not find scrolling capture.

Both stem from the app running as a menu bar (LSUIElement / accessory) app:
- The settings window opened behind other apps / on a different Space, so it appeared as if nothing happened.
- Scrolling capture had a complete backend but was never wired to any UI element.

## Changes

### Settings window activation
- Temporarily switch activation policy to `.regular` so an accessory app can take the foreground, then restore the original policy after the window is shown (stays a menu bar item, no permanent Dock icon).
- Set `collectionBehavior` to `.moveToActiveSpace` + `.fullScreenAuxiliary` so the window appears on the current Space.
- Add `orderFrontRegardless()` after `makeKeyAndOrderFront()`.

### Scrolling capture button
- Add a Scrolling capture button to the tools row in the menu bar popover (next to Ruler, Color, Timed, OCR).
- Wire it to the existing `ScreenCaptureService.startScrollingCapture()`.
- Reuse the existing `menu.scrolling` localization and an `arrow.down.doc` icon.

## Testing

- `xcodebuild ... -destination 'platform=macOS' build` succeeds with zero errors.
- Manual testing recommended: click the gear and confirm the settings window comes to the front on the active Space; verify behavior with "show in Dock" both on and off (the original activation policy is preserved); confirm the new Scrolling button triggers the window picker and stitching flow.
